### PR TITLE
大佬，发现您的项目引入了org.apache.velocity:velocity-engine-core@2.1组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -86,7 +85,7 @@
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.redisson</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Iteris Apache Velocity 安全漏洞
缺陷组件：org.apache.velocity:velocity-engine-core@2.1
漏洞编号：CVE-2020-13936
漏洞描述：Iteris Apache Velocity是美国 （Iteris）公司的一个应用软件。用于创建和维护与Apache Velocity Engine相关的开源软件功能。
Apache Velocity Engine versions up to 2.2 存在安全漏洞，攻击者可利用该漏洞执行任意Java代码或运行任意系统命令。
影响范围：(∞, 2.3)
最小修复版本：2.3
缺陷组件引入路径：cn.hjljy:fastboot@0.0.1-SNAPSHOT->org.apache.velocity:velocity-engine-core@2.1
```
另外我运行这个项目时，IDE的安全插件提示还有10个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pe5038